### PR TITLE
Fix rulesets loading and Internet permission for Android

### DIFF
--- a/osu.Android/OsuGameActivity.cs
+++ b/osu.Android/OsuGameActivity.cs
@@ -7,12 +7,23 @@ using Android.OS;
 using Android.Views;
 using osu.Framework.Android;
 using osu.Game;
+using osu.Game.Rulesets;
 
 namespace osu.Android
 {
     [Activity(Theme = "@android:style/Theme.NoTitleBar", MainLauncher = true, ScreenOrientation = ScreenOrientation.SensorLandscape, SupportsPictureInPicture = false, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, HardwareAccelerated = true)]
     public class OsuGameActivity : AndroidGameActivity
     {
+        static OsuGameActivity()
+        {
+            // When a ruleset assembly is missing, the exception will be thrown during JIT-ing the lambda method
+            // and will be handled in LoadRulesetFromType().
+            RulesetStore.LoadRulesetFromType(() => typeof(Game.Rulesets.Osu.OsuRuleset), "osu");
+            RulesetStore.LoadRulesetFromType(() => typeof(Game.Rulesets.Taiko.TaikoRuleset), "taiko");
+            RulesetStore.LoadRulesetFromType(() => typeof(Game.Rulesets.Mania.ManiaRuleset), "mania");
+            RulesetStore.LoadRulesetFromType(() => typeof(Game.Rulesets.Catch.CatchRuleset), "catch");
+        }
+
         protected override Framework.Game CreateGame()
             => new OsuGame();
 

--- a/osu.Android/Properties/AndroidManifest.xml
+++ b/osu.Android/Properties/AndroidManifest.xml
@@ -5,5 +5,6 @@
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.READ_FRAME_BUFFER" />
+	<uses-permission android:name="android.permission.INTERNET" />
 	<application android:allowBackup="true" android:supportsRtl="true" android:label="osu!lazer" android:icon="@drawable/lazer" />
 </manifest>

--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -22,9 +22,16 @@ namespace osu.Game.Rulesets
         {
             AppDomain.CurrentDomain.AssemblyResolve += currentDomain_AssemblyResolve;
 
-            foreach (string file in Directory.GetFiles(Environment.CurrentDirectory, $"{ruleset_library_prefix}.*.dll")
-                                             .Where(f => !Path.GetFileName(f).Contains("Tests")))
-                loadRulesetFromFile(file);
+            try
+            {
+                foreach (string file in Directory.GetFiles(Environment.CurrentDirectory, $"{ruleset_library_prefix}.*.dll")
+                                                     .Where(f => !Path.GetFileName(f).Contains("Tests")))
+                    loadRulesetFromFile(file);
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Failed to load rulesets from current directory");
+            }
         }
 
         public RulesetStore(IDatabaseContextFactory factory)
@@ -126,6 +133,19 @@ namespace osu.Game.Rulesets
             catch (Exception e)
             {
                 Logger.Error(e, $"Failed to load ruleset {filename}");
+            }
+        }
+
+        public static void LoadRulesetFromType(Func<Type> funcType, string loggingName)
+        {
+            try
+            {
+                var type = funcType();
+                loaded_assemblies[type.Assembly] = type;
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, $"Failed to load ruleset {loggingName}");
             }
         }
     }


### PR DESCRIPTION
Since ruleset assemblies are referenced by the  `osu.Android` project, we can just add ruleset types to RulesetStore.